### PR TITLE
Add support for Ingress networking.k8s.io/v1

### DIFF
--- a/charts/echo-server/templates/ingress.yaml
+++ b/charts/echo-server/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "echo-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -27,6 +29,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
+  {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -38,4 +41,17 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+  {{- else -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              service.name: {{ $fullName }}
+              service.port.number: {{ $svcPort }}
+        {{- end }}
+  {{- end -}}
+  {{- end -}}
 {{- end }}


### PR DESCRIPTION
See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

I couldn't figure out how to discriminate if $svcPort is an integer or not - which means I picked port.number over port.name.  If we could add a conditional and type check that would be ideal.