### PR TITLE
Upgrade networking.k8s.io/v1beta1 to v1

### DIFF
--- a/charts/echo-server/Chart.yaml
+++ b/charts/echo-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "0.4.0"
-version: 0.3.0
+version: 0.3.1
 icon: https://ealenn.github.io/Echo-Server/assets/images/ping-pong.png
 name: echo-server
 description: Echo-Server for Kubernetes

--- a/charts/echo-server/README.md
+++ b/charts/echo-server/README.md
@@ -65,7 +65,7 @@ helm upgrade -i ${name} ealenn/echo-server --namespace ${namespace} --force
 | resources.requests.cpu | string | `"50m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
+| service.port | int | `80` | For k8s >= 1.19 use port number not name |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
@@ -78,6 +78,10 @@ helm upgrade -i ${name} ealenn/echo-server --namespace ${namespace} --force
 - App Version [0.4.2](https://github.com/Ealenn/Echo-Server/releases/tag/0.4.2)
 - Increased architecture
 - Additional Documentation *(thanks prasadkatti)*
+
+### 0.3.1
+
+- Use networking.k8s.io/v1 API for Ingress on kubernetes >= 1.19
 
 ### 0.3.0
 

--- a/charts/echo-server/templates/ingress.yaml
+++ b/charts/echo-server/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "echo-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -27,6 +29,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
+  {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -38,4 +41,17 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+  {{- else -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              service.name: {{ $fullName }}
+              service.port.number: {{ $svcPort }}
+        {{- end }}
+  {{- end -}}
+  {{- end -}}
 {{- end }}

--- a/charts/echo-server/templates/ingress.yaml
+++ b/charts/echo-server/templates/ingress.yaml
@@ -29,7 +29,22 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: ImplementationSpecific
+        {{- end }}
+  {{- end -}}
+  {{- else -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -41,17 +56,5 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
-  {{- else -}}
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            backend:
-              service.name: {{ $fullName }}
-              service.port.number: {{ $svcPort }}
-        {{- end }}
-  {{- end -}}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

I couldn't wait until Hacktoberfest to submit this patch. There is a wrinkle in that I can't figure out how to determin if $svcPort is an integer or string.

