### PR TITLE
[echo-server] make ingress fully compatible with various kubernetes versions

### DIFF
--- a/charts/echo-server/Chart.yaml
+++ b/charts/echo-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "0.6.0"
-version: 0.5.0
+version: 0.6.0
 icon: https://ealenn.github.io/Echo-Server/assets/images/ping-pong.png
 name: echo-server
 description: Echo-Server for Kubernetes

--- a/charts/echo-server/README.md
+++ b/charts/echo-server/README.md
@@ -45,10 +45,10 @@ helm upgrade -i ${name} ealenn/echo-server --namespace ${namespace} --force
 | image.tag | string | `"0.6.0"` | https://github.com/Ealenn/Echo-Server/releases |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Example `kubernetes.io/ingress.class: nginx` for Nginx Ingress |
+| ingress.className | string | `""` | Example `nginx` for Nginx Ingress |
 | ingress.enabled | bool | `false` | Enable ingress |
 | ingress.hosts[0].host | string | `"cluster.local"` |  |
 | ingress.hosts[0].paths[0] | string | `"/"` |  |
-| ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.httpGet.httpHeaders[0].name | string | `"x-echo-code"` |  |
@@ -74,6 +74,10 @@ helm upgrade -i ${name} ealenn/echo-server --namespace ${namespace} --force
 | tolerations | list | `[]` |  |
 
 ## Changelog
+
+### 0.6.0
+
+- Update ingress to be fully compatible with latest Kubernetes versions *(thanks @treksler)*
 
 ### 0.5.0
 

--- a/charts/echo-server/README.md.gotmpl
+++ b/charts/echo-server/README.md.gotmpl
@@ -30,6 +30,10 @@ helm upgrade -i ${name} ealenn/echo-server --namespace ${namespace} --force
 
 ## Changelog
 
+### 0.6.0
+
+- Update ingress to be fully compatible with latest Kubernetes versions *(thanks @treksler)*
+
 ### 0.5.0
 
 - Update echo to 0.6.0 *(thanks @XenGi)*

--- a/charts/echo-server/templates/ingress.yaml
+++ b/charts/echo-server/templates/ingress.yaml
@@ -1,6 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "echo-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -11,53 +16,44 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels:
-{{ include "echo-server.labels" . | indent 4 }}
+  labels: {{- include "echo-server.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
-{{- end }}
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
+          {{- range .paths }}
           - path: {{ . }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            pathType: ImplementationSpecific
-        {{- end }}
-  {{- end -}}
-  {{- else -}}
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            backend:
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-        {{- end }}
-  {{- end }}
-  {{- end -}}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/echo-server/values.yaml
+++ b/charts/echo-server/values.yaml
@@ -28,7 +28,8 @@ service:
 ingress:
   # ingress.enabled -- Enable ingress
   enabled: false
-  ingressClassName: ""
+  # ingress.classNane -- Example nginx for Nginx Ingress
+  className: ""
   # ingress.annotations -- Example `kubernetes.io/ingress.class: nginx` for Nginx Ingress
   annotations: {}
   hosts:


### PR DESCRIPTION
- wrap pathType in a Kubernetes version check
- automatically handle annotations for kubernetes ingress class in older kubernetes versions
- eliminate duplicated code in backed definition